### PR TITLE
Removed ordering by `search_by` column

### DIFF
--- a/django_project/search/tables.py
+++ b/django_project/search/tables.py
@@ -15,7 +15,7 @@ class SearchesTable(tables.Table):
     """
     Renders a table of Search objects
     """
-    searched_by = tables.Column(empty_values=())
+    searched_by = tables.Column(empty_values=(), orderable=False)
     search_date = SANSADateColumn()
     satellites = tables.Column(empty_values=(), orderable=False)
     sensors = tables.Column(empty_values=(), orderable=False)


### PR DESCRIPTION
Hi @cchristelis about issue #79  I guess that has been done. 

The problem that Tim said are:
- The placed by column in the orders list is always empty.
- In search history, searched by column is empty

Everything is ok in te order list page. 
![screen shot 2016-01-27 at 11 53 27 am](https://cloud.githubusercontent.com/assets/2235894/12604317/1d964ab8-c4ed-11e5-9118-54e67256aca2.png)

Then for the search history too, but it produces error when we tried to ordering by `search_by` column. 
In this problem, I removed the feature for ordering by `search_by`. The reason is this feature is useless because this is in `my search histroy` page. All of rows in this colomn filled by same value that is user name. 

![screen shot 2016-01-27 at 11 52 57 am](https://cloud.githubusercontent.com/assets/2235894/12604349/61bb277c-c4ed-11e5-82bf-a469cbd7de25.png)
