### PR TITLE
fixes #137 | remove summary of sensor dictionaries report

### DIFF
--- a/django_project/reports/urls.py
+++ b/django_project/reports/urls.py
@@ -32,9 +32,6 @@ urlpatterns = patterns(
         ),
     url(r'^dataSummaryTable/$', data_summary_table, name='dataSummaryTable'),
     url(r'^dictionaryReport/$', dictionary_report, name='dictionaryReport'),
-    url(r'^sensorSummaryTable/(?P<sensor_id>[0-9]+)/$',
-        sensor_summary_table, name='sensorSummaryTable'
-        ),
     url(r'^sensor-fact-sheet/(?P<sat_abbr>[\w-]+)/(?P<instrument_type>[\w-]+)/$',
         sensor_fact_sheet, name='fact-sheet')
 )


### PR DESCRIPTION
Small PR, just remove sensorSummaryTable from url.py. 
