### PR TITLE
Add version to django-guardian and django-tables2

### DIFF
--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -14,6 +14,7 @@ django-nose==1.2
 django-offline-messages==0.2.6
 django-pipeline==1.3.15
 django-tastypie==0.10.0
+django-guardian==1.3.2
 django-userena==1.3.0
 django-webodt
 docutils==0.7
@@ -47,4 +48,4 @@ raven==3.5.2
 reportlab==2.5
 selenium==2.28.0
 django-exchange==0.7.1
-django-tables2
+django-tables2==1.0.4


### PR DESCRIPTION
If we didn't stated the version, it will download the latest version
which won't work with django 1.6
@cchristelis 
