### PR TITLE
Make search help works

### DIFF
--- a/django_project/catalogue/templates/searchFormHelp.html
+++ b/django_project/catalogue/templates/searchFormHelp.html
@@ -1,3 +1,48 @@
 <div class="modal-body">
-<h1>Help</h1>
+<div class="row-fluid">
+  <h2>Map Help</h2>
+  <div class="row-fluid">
+    <div class="span12">
+      <h3>Using the map</h3>
+      <p>
+        <i class="icon-zoom-in icon-2x"></i>
+        <i class="icon-zoom-out icon-2x"></i>
+        Use the <strong>zoom out and zoom in icons</strong> to zoom in and out on the map by dragging rectangles.
+      </p>
+      <p>
+        <i class="icon-move icon-2x"></i>
+        Use the <strong>pan</strong> icon on the map to enable map panning by dragging the map.
+      </p>
+      <p>
+        <i class="icon-resize-small icon-2x"></i>
+        <i class="icon-fullscreen icon-2x"></i>
+        Use to <strong>restore and fullscreen icons</strong> to quickly resize map window. Restore will resize map to original size, while fullscreen will resize map to fill current browser window.
+      </p>
+      <p>
+        When the pan tool is enabled, and you are viewing search results, you can click on the yellow image footprint in the map to see its preview in the preview area.
+      </p>
+
+      <h3>When searching</h3>
+      <p>
+        Digitising an area of interest is not required but is recommended. Draw an area of interest on the map to refine the set of search results to a specific area.
+      </p>
+      <p>
+        <i class="icon-check-empty icon-2x"></i>
+        Use the <strong>capture</strong> icon on the map to your left to draw an area of interest for your search.
+      </p>
+      <p>
+        <i class="icon-edit icon-2x"></i>
+        Use the <strong>edit</strong> icon on the map to your left to adjust your area of interest for your search.
+      </p>
+
+      <h3>Keyboard shortcuts</h3>
+      <p>
+        Use the <strong>'d' or 'delete'</strong> key (while holding the mouse cursor over it) to delete a vertex when editing the area of interest.
+      </p>
+      <p>
+        Use <strong>shift</strong> while dragging a rectangle on the map to zoom in to that rectangle.
+      </p>
+    </div>
+  </div>
+</div>
 </div>


### PR DESCRIPTION
This PR for [this issue](https://github.com/kartoza/catalogue/issues/367)

Hi @cchristelis based on [this conversation](https://github.com/kartoza/catalogue/issues/367#issuecomment-205149198)

Maite said that he want same content for the search help like a map help. so In this PR, I only change the link for the search help to the mapHelp. 

If the client provides content for the search help, we can add it in searchFormHelp's template. How do you think Christian?

Thanks.
