### PR TITLE
change the repo link

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -14,7 +14,7 @@ ADD 71-apt-cacher-ng /etc/apt/apt.conf.d/71-apt-cacher-ng
 # Pandoc needed to generate rst dumps
 RUN apt-get update -y; apt-get -y --force-yes install yui-compressor pandoc
 RUN apt-get -y install build-essential python-all-dev
-RUN sed -i '1ideb http://ftp.de.debian.org/debian jessie main' /etc/apt/sources.list
+RUN sed -i '1ideb http://ftp.us.debian.org/debian jessie main' /etc/apt/sources.list
 RUN apt-get update -y;
 RUN apt-get install -y abiword --fix-missing
 WORKDIR "/tmp"


### PR DESCRIPTION
Hi @cchristelis I am not sure this one is necessary or not. 
but by this link http://ftp.de.debian.org/debian jessie main I am not able to install abiword. 

```
Unable to correct missing packages.
E: Failed to fetch http://httpredir.debian.org/debian/pool/main/s/systemd/libgudev-1.0-0_215-17+deb8u2_amd64.deb  404  Not Found

E: Failed to fetch http://httpredir.debian.org/debian/pool/main/g/gtk+2.0/libgtk2.0-0_2.24.25-3_amd64.deb  404  Not Found

E: Failed to fetch http://httpredir.debian.org/debian/pool/main/s/systemd/libpam-systemd_215-17+deb8u2_amd64.deb  404  Not Found

E: Failed to fetch http://httpredir.debian.org/debian/pool/main/s/sane-backends/libsane_1.0.24-8_amd64.deb  404  Not Found

E: Failed to fetch http://httpredir.debian.org/debian/pool/main/g/gtk+2.0/libgtk2.0-bin_2.24.25-3_amd64.deb  404  Not Found

E: Failed to fetch http://httpredir.debian.org/debian/pool/main/s/sane-backends/sane-utils_1.0.24-8_amd64.deb  404  Not Found

E: Aborting install.
Service 'uwsgi' failed to build: The command '/bin/sh -c apt-get install -y abiword --fix-missing' returned a non-zero code: 100
make: *** [build] Error 1

```

so, I change to `us`. If you think this is not necessary I'll close this PR. 

Thanks
