### PR TITLE
Make add date range always visible

### DIFF
--- a/django_project/search/templates/search_form/content-2.html
+++ b/django_project/search/templates/search_form/content-2.html
@@ -1,4 +1,4 @@
-<div id="content-2" class="form-horizontal accordion-body collapse">
+<div id="content-2" class="form-horizontal accordion-body collapse in">
   <div class="accordion-inner" style="padding-bottom: 10px;">
     <span id="daterange_inline" class="help-inline"></span>
     <div id="date_from_cg" class="control-group">


### PR DESCRIPTION
Always visible the add date range in the left menu. PR for https://github.com/kartoza/catalogue/issues/368
