### PR TITLE
Fixing broken links and domain in email

### DIFF
--- a/django_project/core/settings/project.py
+++ b/django_project/core/settings/project.py
@@ -64,7 +64,7 @@ GEOIP_CITY = 'GeoLiteCity.dat'
 HOST = '192.168.1.1'
 
 # used in various places including kml generator
-DOMAIN = 'catalogue.localhost'
+DOMAIN = 'catalogue.sansa.org.za'
 
 # Standard page size for pagination
 PAGE_SIZE = 20


### PR DESCRIPTION
for issue https://github.com/kartoza/catalogue/issues/396
Currently when user order images, the domain is catalogue.localhost and links for the imagery is broken. 

![screen shot 2016-05-10 at 12 25 32 pm](https://cloud.githubusercontent.com/assets/2235894/15136290/522c6ea6-16aa-11e6-98d7-e5e2cdc2b37e.png)

This PR is for fixing domain, for the broken links, those link are not broken but because still does not has link. 

to get that link, 

```
def productUrl(self):
        """Returns a path to the actual imagery data as a url. You need to have
        apache set up so share this directory. If no file is encountered at the
        computed path,

        None will be returned"""
        myUrl = (
            settings.IMAGERY_URL_ROOT + self.productDirectory() + '/' +
            self.product_id + '.tif.bz2')
        myPath = os.path.join(
            settings.IMAGERY_ROOT, self.productDirectory(),
            self.product_id + '.tif.bz2')
        if os.path.isfile(myPath):
            return myUrl
        else:
            return None
```

project.py

```
# Url that holds directories of thumbnails...
THUMBS_ROOT = ABS_PATH('thumbs_out')

# And this is the dir that holds imagery
IMAGERY_ROOT = ABS_PATH('imagery_mastercopies')

# The public visible url that imagery should be
# accessed from (include trailing /)
IMAGERY_URL_ROOT = EXTERNAL_SITE_URL + '/imagery/'
```

when imagery directory and files are available the links will showing up. 

thanks. 
