### PR TITLE
fix gdal link

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -18,9 +18,9 @@ RUN sed -i '1ideb http://ftp.de.debian.org/debian jessie main' /etc/apt/sources.
 RUN apt-get update -y;
 RUN apt-get install -y abiword --fix-missing
 WORKDIR "/tmp"
-RUN wget http://download.osgeo.org/gdal/gdal-1.9.0.tar.gz
-RUN tar xvfz gdal-1.9.0.tar.gz
-WORKDIR "/tmp/gdal-1.9.0"
+RUN wget http://download.osgeo.org/gdal/1.10.0/gdal-1.10.0.tar.gz
+RUN tar xvfz gdal-1.10.0.tar.gz
+WORKDIR "/tmp/gdal-1.10.0"
 RUN ./configure --with-python && make && make install
 RUN apt-get -y install python-uno libpq5 python-geoip
 

--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -1,6 +1,6 @@
 #DateUtils==0.6.6
 Django==1.9.5
-GDAL==1.9.0
+GDAL==1.10.0
 #PIL==1.1.7
 pillow
 Pygments==1.4


### PR DESCRIPTION
http://download.osgeo.org/gdal/gdal-1.9.0.tar.gz is no longer valid

also, update gdal to 1.10.0 (previously: 1.9.0)

fix #541